### PR TITLE
restore `warnings.showwarning` value after running pytest

### DIFF
--- a/pytest_bazel/main.py
+++ b/pytest_bazel/main.py
@@ -231,8 +231,12 @@ def main(
     warnings_file = env.test_warnings_output_file
     if warnings_file:
         with warnings_file.open("w") as f:
+            original_showwarning = warnings.showwarning
             warnings.showwarning = _write_to_file_factory(f)
-            exit_code = pytest_main(pytest_args)
+            try:
+                exit_code = pytest_main(pytest_args)
+            finally:
+                warnings.showwarning = original_showwarning
     else:
         exit_code = pytest_main(pytest_args)
 

--- a/tests/main/test_pytest_base.py
+++ b/tests/main/test_pytest_base.py
@@ -1,3 +1,4 @@
+import warnings
 from pathlib import Path
 
 from pytest_bazel.main import BazelEnv
@@ -67,6 +68,23 @@ def test_no_sharding_by_default(tmpdir):
     assert (
         not shard_status_file.exists()
     ), "Sharding should not be advertised as supported"
+
+
+def test_pytest_showwarning():
+    """Ensure that the original warning function is restored after pytest runs."""
+
+    original_showwarning = warnings.showwarning
+
+    got_args = []
+    _main(
+        pytest_main=lambda args: mock_pytest_main(args, collect_args=got_args),
+    )
+    assert warnings.showwarning == original_showwarning
+
+    _main(
+        pytest_main=lambda args: mock_pytest_main(args, return_exit=42),
+    )
+    assert warnings.showwarning == original_showwarning
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Overview

It seems that I'm getting the errors described in https://github.com/bazel-contrib/rules_python/issues/2762, but only when using `pytest-bazel`.

```
  File "/private/var/tmp/username/hash/sandbox/darwin-sandbox/code/test.runfiles/pypi_pytest_bazel/site-packages/pytest_bazel/__init__.py", line 39, in main
    sys.exit(_main(args=args))
SystemExit: ExitCode.OK

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/private/var/tmp/username/hash/sandbox/darwin-sandbox/code/test.runfiles/mycode/_test_stage2_bootstrap.py", line 547, in <module>
    main()
  File "/private/var/tmp/username/hash/sandbox/darwin-sandbox/code/test.runfiles/mycode/_test_stage2_bootstrap.py", line 541, in main
    with _maybe_collect_coverage(enable=cov_tool is not None):
  File "/private/var/tmp/username/hash/execroot/_main/external/python/lib/python3.10/warnings.py", line 109, in _showwarnmsg
    sw(msg.message, msg.category, msg.filename, msg.lineno,
  File "/private/var/tmp/username/hash/sandbox/darwin-sandbox/9/execroot/_main/bazel-out/mycode/test.runfiles/pypi_pytest_bazel/site-packages/pytest_bazel/main.py", line 42, in _fn
    out_file.write(
ValueError: I/O operation on closed file.
--
Coverage runner: Not collecting coverage for failed test.
The following commands failed with status 1
```

The issue seems to be caused by the overridden `warnings.showwarning` before running **pytest**. However, after all is done, any other `warning.warn()` calls still use the `_write_to_file_factory(f)` which writes to the file dictated by the env var `TEST_WARNINGS_OUTPUT_FILE`.

## Proposed Solution

The previous `warnings.showwarning` value is restored after running **pytest**.

Any another exception in still propagated through the stack trace as we don't catch them via the `except` clause. This prevents any other issue to not be unintentionally hidden.

With this, the errors disappear on my end. 🎉 