### PR TITLE
fix: Fix logic bug where sharding is not initialized for the 0 shard

### DIFF
--- a/pytest_bazel/main.py
+++ b/pytest_bazel/main.py
@@ -49,6 +49,8 @@ def _write_to_file_factory(out_file):
 def _maybe_path(p) -> Optional[Path]:
     return Path(p) if p else None
 
+def _maybe_int(v: Optional[str]) -> Optional[int]:
+    return int(v) if v is not None else None
 
 @dataclass
 class BazelEnv:
@@ -60,9 +62,9 @@ class BazelEnv:
     env: Dict[str, str]
 
     @property
-    def test_shard_index(self) -> int:
+    def test_shard_index(self) -> Optional[int]:
         """Return the TEST_SHARD_INDEX value."""
-        return int(self.env.get("TEST_SHARD_INDEX") or 0)
+        return _maybe_int(self.env.get("TEST_SHARD_INDEX"))
 
     @property
     def test_shard_status_file(self) -> Optional[Path]:
@@ -72,7 +74,7 @@ class BazelEnv:
     @property
     def test_total_shards(self) -> int:
         """Return the TEST_TOTAL_SHARDS value."""
-        return int(self.env.get("TEST_TOTAL_SHARDS") or 0)
+        return _maybe_int(self.env.get("TEST_TOTAL_SHARDS"))
 
     @property
     def test_random_seed(self) -> int:
@@ -197,7 +199,7 @@ def _pytest_args(*, args: List[str], env: BazelEnv) -> List[str]:
         pytest_args.append(f"--randomly-seed={random_seed}")  # using pytest-randomly
 
     # Handle test sharding - requires pytest-shard plugin.
-    if env.test_shard_index and env.test_total_shards:
+    if env.test_shard_index is not None and env.test_total_shards is not None:
         # https://bazel.build/reference/test-encyclopedia#test-sharding
         pytest_args.append(f"--shard-id={env.test_shard_index}")
         pytest_args.append(f"--num-shards={env.test_total_shards}")

--- a/tests/main/test_pytest_base.py
+++ b/tests/main/test_pytest_base.py
@@ -1,9 +1,24 @@
+import pytest
 import warnings
 from pathlib import Path
 
+from pytest_bazel.main import _supports_sharding
 from pytest_bazel.main import BazelEnv
 from pytest_bazel.main import main as _main
 
+@pytest.fixture
+def mock_supports_sharding():
+    """Mock _supports_sharding to always return True."""
+
+    def mock_supports_sharding_fn():
+        return True
+
+    previous_supports_sharding = _supports_sharding.__code__
+    _supports_sharding.__code__ = mock_supports_sharding_fn.__code__
+
+    yield
+
+    _supports_sharding.__code__ = previous_supports_sharding
 
 def mock_pytest_main(args=None, collect_args=None, return_exit=0):
     if args and collect_args is not None:
@@ -69,6 +84,31 @@ def test_no_sharding_by_default(tmpdir):
         not shard_status_file.exists()
     ), "Sharding should not be advertised as supported"
 
+@pytest.mark.parametrize(
+    ("shard_index", "total_shards"),
+    [
+        (0, 2),
+        (1, 2),
+        (2, 2),
+    ],
+)
+def test_sharding_enabled(tmpdir, mock_supports_sharding, shard_index: int, total_shards: int):
+    """Ensure that sharding and working when supported."""
+
+    shard_status_file = Path(tmpdir) / f"mock_file_{shard_index}"
+    _main(
+        pytest_main=lambda args: mock_pytest_main(args),
+        env=BazelEnv(
+            {
+                "TEST_SHARD_INDEX": str(shard_index),
+                "TEST_TOTAL_SHARDS": str(total_shards),
+                "TEST_SHARD_STATUS_FILE": str(shard_status_file),
+                "BAZEL_TEST": "1",
+            }
+        ),
+    )
+
+    assert shard_status_file.exists(), "Sharding should be advertised as supported"
 
 def test_pytest_showwarning():
     """Ensure that the original warning function is restored after pytest runs."""


### PR DESCRIPTION
The logic to initialize sharding checked if shard count was truthy, when in reality it should check if it is not None. This caused sharding to never be initialized for the 0'th shard.

Included a previously failing test that now passes.